### PR TITLE
Create root volume for postgres primary separately

### DIFF
--- a/database/postgres/postgres.yaml
+++ b/database/postgres/postgres.yaml
@@ -387,7 +387,18 @@ resources:
               partition: 1
             mounts: [ [ LABEL=backupvol, /mnt/backup, ext4, 'defaults,noatime' ] ]
           - { }
+  primary_volume:
+     type: OS::Cinder::Volume
+     properties:
+       image: ubuntu-jammy-22-x86_64
+       availability_zone: { get_param: pri_az }
+       size:
+         yaql:
+           expression: int(max(6 + $.data.size, 20))
+           data:
+             size: { get_param: data_size }
   primary_instance:
+    depends_on: primary_volume
     type: OS::Nova::Server
     properties:
       name:
@@ -403,12 +414,7 @@ resources:
         list_concat:
         - - boot_index: 0
             delete_on_termination: false
-            image: ubuntu-jammy-22-x86_64
-            volume_size:
-              yaql:
-                expression: int(max(6 + $.data.size, 20))
-                data:
-                  size: { get_param: data_size }
+            volume_id: { get_resource: primary_volume }
             disk_bus: virtio
         - if:
           - do_backup
@@ -426,7 +432,7 @@ resources:
     type: OS::Heat::WaitCondition
     properties:
       handle: { get_resource: wait_handle }
-      timeout: 600
+      timeout: 1200
   wait_handle:
     type: OS::Heat::WaitConditionHandle
   primary_site_replica_nodes:


### PR DESCRIPTION
This does the same done for the replica [1] where we create the root volume separately and not within the block-device-mappings so that we can specify an AZ.

[1] https://github.com/binerogroup/heat-templates/pull/1